### PR TITLE
79 wait command implementation

### DIFF
--- a/src/actors/messages.rs
+++ b/src/actors/messages.rs
@@ -85,7 +85,8 @@ pub enum ReplicatorActorMessage {
         replication_value: ReplicationSectionData,
     },
     GetReplicaCount {
-        respond_to: oneshot::Sender<usize>, // total number of connected, synced up replicas
+        respond_to: oneshot::Sender<usize>, // reply with total number of connected, synced up replicas
+        target_offset: i16,
     },
 
     ResetReplicaOffset {
@@ -135,7 +136,7 @@ pub enum ProcessorActorMessage {
         // NOTE: a single request like PSYNC can return multiple responses.
         // So, where a Vec<u8> is a single reponse, a Vec<Vec<u8>> is multiple responses.
         respond_to: oneshot::Sender<Option<Vec<RespValue>>>,
-        wait_sleep_tx: Option<mpsc::Sender<()>>,
+        wait_sleep_tx: Option<mpsc::Sender<i16>>,
     },
 }
 

--- a/src/actors/processor.rs
+++ b/src/actors/processor.rs
@@ -622,9 +622,17 @@ impl ProcessorActor {
                                 let replconf_getack_star: RespValue =
                                     RespValue::array_from_slice(&["REPLCONF", "GETACK", "*"]);
 
+                                let current_master_offset = replication_actor_handle
+                                    .get_value(HostId::Myself)
+                                    .await
+                                    .expect("Expected to always have self information.")
+                                    .master_repl_offset
+                                    .expect("Master always has offset.");
+
                                 // get the replica count
-                                let replicas_in_sync =
-                                    replication_actor_handle.get_synced_replica_count().await;
+                                let replicas_in_sync = replication_actor_handle
+                                    .get_synced_replica_count(current_master_offset)
+                                    .await;
 
                                 info!("We have {replicas_in_sync} replicas in sync.");
 
@@ -674,6 +682,7 @@ impl ProcessorActor {
                                             "IF we are processing WAIT this must be present.",
                                         ),
                                         duration,
+                                        current_master_offset,
                                     )
                                     .await;
 

--- a/src/actors/replicator.rs
+++ b/src/actors/replicator.rs
@@ -163,14 +163,12 @@ impl ReplicatorActor {
             ReplicatorActorMessage::GetReplicaCount { respond_to } => {
                 // first, let's get the master offset. It's ok to panic here because this should never fail.
                 // if it were to fail, we can't proceed anyway.
-                let master_offset = (self
+                let master_offset = self
                     .kv_hash
                     .get(&HostId::Myself)
                     .expect("Something is wrong, expected to find master offset.")
                     .master_repl_offset
-                    .expect("Expected master to have an offset, panic otherwise.")
-                    - 37)
-                    .max(0); // -37 is `REPLCONF GETACK *` but let's not go negative here!
+                    .expect("Expected master to have an offset, panic otherwise.") - 37; // -37 is REPLCONF GETACK *
 
                 // dump the contents of the hashmap to the console
                 // info!("kv_hash: {:?}", self.kv_hash);

--- a/src/actors/replicator.rs
+++ b/src/actors/replicator.rs
@@ -163,12 +163,14 @@ impl ReplicatorActor {
             ReplicatorActorMessage::GetReplicaCount { respond_to } => {
                 // first, let's get the master offset. It's ok to panic here because this should never fail.
                 // if it were to fail, we can't proceed anyway.
-                let master_offset = self
+                let master_offset = (self
                     .kv_hash
                     .get(&HostId::Myself)
                     .expect("Something is wrong, expected to find master offset.")
                     .master_repl_offset
-                    .expect("Expected master to have an offset, panic otherwise.") - 37; // -37 is REPLCONF GETACK *
+                    .expect("Expected master to have an offset, panic otherwise.")
+                    - 37)
+                    .max(0); // -37 is `REPLCONF GETACK *` but let's not go negative here!
 
                 // dump the contents of the hashmap to the console
                 // info!("kv_hash: {:?}", self.kv_hash);

--- a/src/actors/replicator.rs
+++ b/src/actors/replicator.rs
@@ -160,20 +160,22 @@ impl ReplicatorActor {
 
                 // self.kv_hash.insert(host_id, replication_value);
             }
-            ReplicatorActorMessage::GetReplicaCount { respond_to } => {
+            ReplicatorActorMessage::GetReplicaCount { respond_to, target_offset } => {
                 // first, let's get the master offset. It's ok to panic here because this should never fail.
                 // if it were to fail, we can't proceed anyway.
-                let master_offset = self
-                    .kv_hash
-                    .get(&HostId::Myself)
-                    .expect("Something is wrong, expected to find master offset.")
-                    .master_repl_offset
-                    .expect("Expected master to have an offset, panic otherwise.") - 37; // -37 is REPLCONF GETACK *
+                // let master_offset = self
+                //     .kv_hash
+                //     .get(&HostId::Myself)
+                //     .expect("Something is wrong, expected to find master offset.")
+                //     .master_repl_offset
+                //     .expect("Expected master to have an offset, panic otherwise.") - 37; // -37 is REPLCONF GETACK *
+
+
 
                 // dump the contents of the hashmap to the console
                 // info!("kv_hash: {:?}", self.kv_hash);
 
-                info!("Looking for replicas with offset of {:?}", master_offset);
+                info!("Looking for replicas with offset of {:?}", target_offset);
 
                 // now, let's count how many replicas have this offset
                 // Again, avoid counting HostId::Myself
@@ -199,7 +201,7 @@ impl ReplicatorActor {
                             // next, let's check for offset
                             if let Some(slave_offset) = v.master_repl_offset {
                                 // ok, this replica does have an offset, let's compare
-                                if slave_offset == master_offset {
+                                if slave_offset == target_offset {
                                     replica_count += 1;
                                 }
                             }

--- a/src/handlers/replication.rs
+++ b/src/handlers/replication.rs
@@ -87,9 +87,9 @@ impl ReplicationActorHandle {
     }
 
     /// Returns the number of replicas that are in sync.
-    pub async fn get_synced_replica_count(&self) -> usize {
+    pub async fn get_synced_replica_count(&self, target_offset: i16) -> usize {
         let (send, recv) = oneshot::channel();
-        let msg = ReplicatorActorMessage::GetReplicaCount { respond_to: send };
+        let msg = ReplicatorActorMessage::GetReplicaCount { respond_to: send, target_offset };
 
         // Ignore send errors. If this send fails, so does the
         // recv.await below. There's no reason to check the

--- a/src/handlers/request_processor.rs
+++ b/src/handlers/request_processor.rs
@@ -46,7 +46,7 @@ impl RequestProcessorActorHandle {
         master_tx: mpsc::Sender<String>,
         replica_tx: broadcast::Sender<RespValue>, // we get this from master handler only
         client_or_replica_tx: Option<mpsc::Sender<bool>>,
-        wait_sleep_tx: Option<mpsc::Sender<()>>,
+        wait_sleep_tx: Option<mpsc::Sender<i16>>,
     ) -> Option<Vec<RespValue>> {
         tracing::debug!("Processing request: {:?}", request);
         // create a multiple producer, single consumer channel

--- a/src/main.rs
+++ b/src/main.rs
@@ -322,7 +322,7 @@ async fn handle_connection_from_clients(
     let (client_or_replica_tx, mut client_or_replica_rx) = mpsc::channel::<bool>(3);
 
     // Create a channel for notifying the main loop when WAIT N NNN is done waiting
-    let (wait_sleep_tx, mut wait_sleep_rx) = mpsc::channel::<()>(1);
+    let (wait_sleep_tx, mut wait_sleep_rx) = mpsc::channel::<i16>(10); // i16 here is the target_offset
 
     let mut am_i_replica: bool = false;
 
@@ -412,8 +412,8 @@ async fn handle_connection_from_clients(
                 info!("Updated client {:?} replica status to {}", host_id, am_i_replica);
             // // }
          }
-         Some(_wakeup) = wait_sleep_rx.recv() => { // j/k - wakeup is nothing
-            let replicas_in_sync = replication_actor_handle.get_synced_replica_count().await;
+         Some(target_offset) = wait_sleep_rx.recv() => { // j/k - wakeup is nothing
+            let replicas_in_sync = replication_actor_handle.get_synced_replica_count(target_offset).await;
 
             let _ = writer.send(RespValue::Integer(replicas_in_sync as i64)).await?;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -41,13 +41,13 @@ use rand::{thread_rng, Rng};
 use std::iter;
 // ----------
 
-pub async fn sleeping_task(wait_sleep_tx: mpsc::Sender<()>, duration: Duration) -> JoinHandle<()> {
+pub async fn sleeping_task(wait_sleep_tx: mpsc::Sender<i16>, duration: Duration, target_offset: i16) -> JoinHandle<()> {
     let handle = tokio::spawn(async move {
         info!("Sleeping thread started.");
         sleep(duration).await;
         info!("Sleeping thread finished.");
         wait_sleep_tx
-            .send(())
+            .send(target_offset) // we are passing this around to avoid advancing the offset prematurely
             .await
             .expect("This should have succeeded.");
     });


### PR DESCRIPTION
Notes
The `WAIT` command should return when either (a) the specified number of replicas have acknowledged the command, or (b) the timeout expires.
The `WAIT` command should always return the number of replicas that have acknowledged the command, even if the timeout expires.
The returned number of replicas might be lesser than or greater than the expected number of replicas specified in the `WAIT` command.

Closes #79 